### PR TITLE
Add support for enchantment descriptions.

### DIFF
--- a/src/main/resources/assets/mcdar/lang/en_us.json
+++ b/src/main/resources/assets/mcdar/lang/en_us.json
@@ -45,6 +45,11 @@
   "enchantment.mcdar.beast_burst":        "Beast Burst",
   "enchantment.mcdar.beast_surge":        "Beast Surge",
   "enchantment.mcdar.cooldown":           "Cooldown",
+  
+  "enchantment.mcdar.beast_boss.desc":    "Increases the damage dealt by summoned creatures.",
+  "enchantment.mcdar.beast_burst.desc":   "Drinking a health potion will cause summoned creatures to emit an explosion.",
+  "enchantment.mcdar.beast_surge.desc":   "Drinking a health potion will cause give summoned creatures a speed and strength boost.",
+  "enchantment.mcdar.cooldown.desc":      "Reduces the artefact cooldown timer.",
 
   "tooltip_info_item.mcdar.blast_fungus_1":               "Only the bravest of warriors carry",
   "tooltip_info_item.mcdar.blast_fungus_2":               "the Blast Fungus. Not just because",


### PR DESCRIPTION
This Pull Request adds support for mods that display enchantments for descriptions such as [Enchantment Descriptions](https://www.curseforge.com/minecraft/mc-mods/enchantment-descriptions).